### PR TITLE
Contracts: validate valueToken decimals in brandedToken constructor

### DIFF
--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -143,11 +143,12 @@ contract BrandedToken is Organized, EIP20Token {
      *      tokens (1:3.5), _conversionRate == 35 and
      *      _conversionRateDecimals == 1.
      *
+     *      The value token is expected to have a `decimals` function.
+     *
      *      Constructor requires:
      *          - valueToken address is not zero
      *          - conversionRate is not zero
      *          - conversionRateDecimals is not greater than 5
-     *          - valueToken has a `decimals` function
      *          - valueToken.decimals == decimals
      *
      * @param _valueToken The value to which valueToken is set.
@@ -193,14 +194,6 @@ contract BrandedToken is Organized, EIP20Token {
         conversionRate = _conversionRate;
         conversionRateDecimals = _conversionRateDecimals;
 
-        bytes memory data = abi.encodeWithSignature("decimals()");
-        (, bytes memory returnData) = address(_valueToken).call(data);
-
-        // Confirm that valueToken has an EIP20 `decimals` function
-        require(
-            returnData.length != 0,
-            'ValueToken does not have an EIP20 decimals function.'
-        );
         require(
             _valueToken.decimals() == _decimals,
             "ValueToken decimals does not equal brandedToken decimals."

--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -190,6 +190,19 @@ contract BrandedToken is Organized, EIP20Token {
         valueToken = _valueToken;
         conversionRate = _conversionRate;
         conversionRateDecimals = _conversionRateDecimals;
+
+        bytes memory data = abi.encodeWithSignature("decimals()");
+        (, bytes memory returnData) = address(_valueToken).call(data);
+
+        // Confirm that valueToken has an EIP20 `decimals` function
+        require(
+            returnData.length != 0,
+            'ValueToken does not have an EIP20 decimals function.'
+        );
+        require(
+            _valueToken.decimals() == _decimals,
+            "ValueToken decimals does not equal brandedToken decimals."
+        );
     }
 
 

--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -147,6 +147,8 @@ contract BrandedToken is Organized, EIP20Token {
      *          - valueToken address is not zero
      *          - conversionRate is not zero
      *          - conversionRateDecimals is not greater than 5
+     *          - valueToken has a `decimals` function
+     *          - valueToken.decimals == decimals
      *
      * @param _valueToken The value to which valueToken is set.
      * @param _symbol The value to which tokenSymbol, defined in EIP20Token,

--- a/contracts/test/eip20token/EIP20TokenMockFail.sol
+++ b/contracts/test/eip20token/EIP20TokenMockFail.sol
@@ -16,12 +16,37 @@ pragma solidity ^0.5.0;
 // limitations under the License.
 
 
+
+
+import "../../EIP20TokenMock.sol";
+
+
 /**
  *  @title Mock EIP20 Token Fail.
  *
  *  @notice Mocks EIP20 token functions as failing.
  */
-contract EIP20TokenMockFail {
+contract EIP20TokenMockFail is EIP20TokenMock {
+
+    /* Constructor */
+
+    /**
+     * @param _symbol The value to which tokenSymbol, defined in EIP20Token,
+     *                is set.
+     * @param _name The value to which tokenName, defined in EIP20Token,
+     *              is set.
+     * @param _decimals The value to which tokenDecimals, defined in EIP20Token,
+     *                  is set.
+     */
+    constructor(
+        string memory _symbol,
+        string memory _name,
+        uint8 _decimals
+    )
+        EIP20TokenMock(_symbol, _name, _decimals)
+        public
+    { }
+
 
     /* External Functions */
 
@@ -35,8 +60,7 @@ contract EIP20TokenMockFail {
         address,
         uint256
     )
-        external
-        pure
+        public
         returns (bool)
     {
         return false;

--- a/contracts/test/eip20token/EIP20TokenMockPass.sol
+++ b/contracts/test/eip20token/EIP20TokenMockPass.sol
@@ -16,12 +16,35 @@ pragma solidity ^0.5.0;
 // limitations under the License.
 
 
+import "../../EIP20TokenMock.sol";
+
+
 /**
  *  @title Mock EIP20 Token Pass.
  *
  *  @notice Mocks EIP20 token functions as passing.
  */
-contract EIP20TokenMockPass {
+contract EIP20TokenMockPass is EIP20TokenMock {
+
+    /* Constructor */
+
+    /**
+     * @param _symbol The value to which tokenSymbol, defined in EIP20Token,
+     *                is set.
+     * @param _name The value to which tokenName, defined in EIP20Token,
+     *              is set.
+     * @param _decimals The value to which tokenDecimals, defined in EIP20Token,
+     *                  is set.
+     */
+    constructor(
+        string memory _symbol,
+        string memory _name,
+        uint8 _decimals
+    )
+        EIP20TokenMock(_symbol, _name, _decimals)
+        public
+    { }
+
 
     /* External Functions */
 
@@ -35,8 +58,7 @@ contract EIP20TokenMockPass {
         address,
         uint256
     )
-        external
-        pure
+        public
         returns (bool)
     {
         return true;
@@ -51,8 +73,7 @@ contract EIP20TokenMockPass {
         address,
         uint256
     )
-        external
-        pure
+        public
         returns (bool)
     {
         return true;

--- a/contracts/test/eip20token/EIP20TokenMockPassFail.sol
+++ b/contracts/test/eip20token/EIP20TokenMockPassFail.sol
@@ -16,6 +16,9 @@ pragma solidity ^0.5.0;
 // limitations under the License.
 
 
+import "../../EIP20TokenMock.sol";
+
+
 /**
  *  @title Mock EIP20 Token Pass Fail.
  *
@@ -24,7 +27,27 @@ pragma solidity ^0.5.0;
  *          functions that invoke transfer but can only be successfully
  *          called after successfully invoking transferFrom.
  */
-contract EIP20TokenMockPassFail {
+contract EIP20TokenMockPassFail is EIP20TokenMock {
+
+    /* Constructor */
+
+    /**
+     * @param _symbol The value to which tokenSymbol, defined in EIP20Token,
+     *                is set.
+     * @param _name The value to which tokenName, defined in EIP20Token,
+     *              is set.
+     * @param _decimals The value to which tokenDecimals, defined in EIP20Token,
+     *                  is set.
+     */
+    constructor(
+        string memory _symbol,
+        string memory _name,
+        uint8 _decimals
+    )
+        EIP20TokenMock(_symbol, _name, _decimals)
+        public
+    { }
+
 
     /* External Functions */
 
@@ -41,8 +64,7 @@ contract EIP20TokenMockPassFail {
         address,
         uint256
     )
-        external
-        pure
+        public
         returns (bool)
     {
         return true;
@@ -57,8 +79,7 @@ contract EIP20TokenMockPassFail {
         address,
         uint256
     )
-        external
-        pure
+        public
         returns (bool)
     {
         return false;

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -203,7 +203,7 @@ contract('BrandedToken::acceptStakeRequest', async () => {
 
       // Setup brandedToken
       const brandedToken = await BrandedToken.new(
-        (await EIP20TokenMockPass.new()).address,
+        (await EIP20TokenMockPass.new('VT', 'ValueToken', 18)).address,
         'BT',
         'BrandedToken',
         config.decimals,

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -198,12 +198,17 @@ contract('BrandedToken::acceptStakeRequest', async () => {
       // Setup organization
       const organization = await OrganizationMockWorker.new();
       const worker = accountProvider.get();
+      const valueToken = await EIP20TokenMockPass.new(
+        'VT',
+        'ValueToken',
+        config.decimals,
+      );
 
       await organization.setWorker(worker, 0);
 
       // Setup brandedToken
       const brandedToken = await BrandedToken.new(
-        (await EIP20TokenMockPass.new('VT', 'ValueToken', 18)).address,
+        valueToken.address,
         'BT',
         'BrandedToken',
         config.decimals,

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -22,6 +22,22 @@ const config = require('../test_lib/config');
 const utils = require('../test_lib/utils');
 
 const BrandedToken = artifacts.require('BrandedToken');
+const EIP20TokenMock = artifacts.require('EIP20TokenMock');
+
+/**
+ * Deploys an EIP20TokenMock contract with the provided decimals.
+ * @param {number} decimals Decimals for token.
+ * @return {string} valueToken Address of token.
+ */
+const deployValueToken = async (decimals) => {
+  const { address: valueToken } = await EIP20TokenMock.new(
+    'VT',
+    'ValueToken',
+    decimals,
+  );
+
+  return valueToken;
+};
 
 contract('BrandedToken::constructor', async () => {
   contract('Negative Tests', async (accounts) => {
@@ -52,8 +68,50 @@ contract('BrandedToken::constructor', async () => {
       );
     });
 
-    it('Reverts if conversionRate is zero', async () => {
+    it('Reverts if valueToken does not have an EIP20 decimals function', async () => {
       const valueToken = accountProvider.get();
+      const conversionRate = 35;
+      const conversionRateDecimals = 1;
+
+      await utils.expectRevert(
+        BrandedToken.new(
+          valueToken,
+          symbol,
+          name,
+          decimals,
+          conversionRate,
+          conversionRateDecimals,
+          organization,
+        ),
+        'Should revert as valueToken does not have an EIP20 decimals function.',
+        'ValueToken does not have an EIP20 decimals function.',
+      );
+    });
+
+    it('Reverts if valueToken decimals does not equal brandedToken decimals', async () => {
+      const valueToken = await deployValueToken(decimals + 1);
+
+      const conversionRate = 35;
+      const conversionRateDecimals = 1;
+
+      await utils.expectRevert(
+        BrandedToken.new(
+          valueToken,
+          symbol,
+          name,
+          decimals,
+          conversionRate,
+          conversionRateDecimals,
+          organization,
+        ),
+        'Should revert as valueToken decimals does not equal brandedToken decimals.',
+        'ValueToken decimals does not equal brandedToken decimals.',
+      );
+    });
+
+    it('Reverts if conversionRate is zero', async () => {
+      const valueToken = await deployValueToken(decimals);
+
       const conversionRate = 0;
       const conversionRateDecimals = 1;
 
@@ -73,7 +131,8 @@ contract('BrandedToken::constructor', async () => {
     });
 
     it('Reverts if conversionRateDecimals is greater than 5', async () => {
-      const valueToken = accountProvider.get();
+      const valueToken = await deployValueToken(decimals);
+
       const conversionRate = 35;
       const conversionRateDecimals = 6;
 
@@ -102,7 +161,8 @@ contract('BrandedToken::constructor', async () => {
     const organization = accountProvider.get();
 
     it('Successfully sets state variables', async () => {
-      const valueToken = accountProvider.get();
+      const valueToken = await deployValueToken(decimals);
+
       const conversionRate = 35;
       const conversionRateDecimals = 1;
 

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -68,26 +68,6 @@ contract('BrandedToken::constructor', async () => {
       );
     });
 
-    it('Reverts if valueToken does not have an EIP20 decimals function', async () => {
-      const valueToken = accountProvider.get();
-      const conversionRate = 35;
-      const conversionRateDecimals = 1;
-
-      await utils.expectRevert(
-        BrandedToken.new(
-          valueToken,
-          symbol,
-          name,
-          decimals,
-          conversionRate,
-          conversionRateDecimals,
-          organization,
-        ),
-        'Should revert as valueToken does not have an EIP20 decimals function.',
-        'ValueToken does not have an EIP20 decimals function.',
-      );
-    });
-
     it('Reverts if valueToken decimals does not equal brandedToken decimals', async () => {
       const valueToken = await deployValueToken(decimals + 1);
 

--- a/test/branded_token/request_stake.js
+++ b/test/branded_token/request_stake.js
@@ -82,7 +82,7 @@ contract('BrandedToken::requestStake', async () => {
     });
 
     it('Reverts if valueToken.transferFrom returns false', async () => {
-      const valueToken = await EIP20TokenMockFail.new();
+      const valueToken = await EIP20TokenMockFail.new('VT', 'ValueToken', 18);
 
       const brandedToken = await BrandedToken.new(
         valueToken.address,

--- a/test/branded_token/request_stake.js
+++ b/test/branded_token/request_stake.js
@@ -82,7 +82,11 @@ contract('BrandedToken::requestStake', async () => {
     });
 
     it('Reverts if valueToken.transferFrom returns false', async () => {
-      const valueToken = await EIP20TokenMockFail.new('VT', 'ValueToken', 18);
+      const valueToken = await EIP20TokenMockFail.new(
+        'VT',
+        'ValueToken',
+        config.decimals,
+      );
 
       const brandedToken = await BrandedToken.new(
         valueToken.address,

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -32,16 +32,21 @@ module.exports.setupBrandedToken = async (
   useOrganizationMockPass = true,
   useEIP20TokenMockPass = true,
 ) => {
-  const valueToken = await (
-    useEIP20TokenMockPass ? EIP20TokenMockPass.new() : EIP20TokenMockPassFail.new()
-  );
   const symbol = 'BT';
   const name = 'BrandedToken';
   const { decimals } = config;
   const conversionRate = 35;
   const conversionRateDecimals = 1;
+
+  const valueToken = await (
+    useEIP20TokenMockPass
+      ? EIP20TokenMockPass.new('VT', 'ValueToken', decimals)
+      : EIP20TokenMockPassFail.new('VT', 'ValueToken', decimals)
+  );
   const organization = await (
-    useOrganizationMockPass ? OrganizationMockPass.new() : OrganizationMockFail.new()
+    useOrganizationMockPass
+      ? OrganizationMockPass.new()
+      : OrganizationMockFail.new()
   );
 
   const brandedToken = await BrandedToken.new(


### PR DESCRIPTION
This PR adds validation to confirm that the decimals of the provided `_valueToken` match the provided `_decimals` for a `BrandedToken` upon construction.

✏️ N.B. 1: as a result of these new validations, previously thin mock contracts needed to be thickened—it seemed more prudent to inherit from the existing `EIP20TokenMock` than to add a new contract to have a constructor that takes decimals and hard-coding the decimals value is inconsistent with the strategy around this issue.

✏️ N.B. 2: `call` returns `true` if the address called does not have any code; consequently, the returned boolean is not checked and only the returned bytes are relied upon.

Resolves #171.