### PR TITLE
Test: update unit tests to handle arbitrary token decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build-package": "node tools/build_package.js",
     "compile-all": "truffle compile --all",
     "test": "truffle test",
+    "test:range": "./tools/test_range.sh",
     "prepack": "npm run compile-all && npm run build-package",
     "lint": "eslint migrations/*.js test/*/*.js tools/*.js -c .eslintrc"
   },

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -23,6 +23,7 @@ const { Event } = require('../test_lib/event_decoder.js');
 const web3 = require('../test_lib/web3.js');
 const utils = require('../test_lib/utils');
 const brandedTokenUtils = require('./utils');
+const config = require('../test_lib/config');
 
 const BrandedToken = artifacts.require('BrandedToken');
 const EIP20TokenMockPass = artifacts.require('EIP20TokenMockPass');
@@ -205,7 +206,7 @@ contract('BrandedToken::acceptStakeRequest', async () => {
         (await EIP20TokenMockPass.new()).address,
         'BT',
         'BrandedToken',
-        18,
+        config.decimals,
         35,
         1,
         organization.address,

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -18,6 +18,7 @@
 const BN = require('bn.js');
 const { AccountProvider } = require('../test_lib/utils.js');
 
+const config = require('../test_lib/config');
 const utils = require('../test_lib/utils');
 
 const BrandedToken = artifacts.require('BrandedToken');
@@ -28,7 +29,7 @@ contract('BrandedToken::constructor', async () => {
 
     const symbol = 'BT';
     const name = 'BrandedToken';
-    const decimals = 18;
+    const { decimals } = config;
     const organization = accountProvider.get();
 
     it('Reverts if valueToken is zero', async () => {
@@ -97,7 +98,7 @@ contract('BrandedToken::constructor', async () => {
 
     const symbol = 'BT';
     const name = 'BrandedToken';
-    const decimals = 18;
+    const { decimals } = config;
     const organization = accountProvider.get();
 
     it('Successfully sets state variables', async () => {

--- a/test/branded_token/convert_to_branded_tokens.js
+++ b/test/branded_token/convert_to_branded_tokens.js
@@ -87,10 +87,9 @@ contract('BrandedToken::convertToBrandedTokens', async () => {
         0,
       );
 
-      // N.B.: values above are miniscule, because the
-      //       decimals for the test tokens are 18; consequently,
-      //       the potential for and degree of loss
-      //       as indicated above is considered acceptable
+      // N.B.: the potential for and degree of loss
+      //       as indicated above is considered acceptable,
+      //       depending on the number of decimal places (e.g., 18)
     });
   });
 });

--- a/test/branded_token/convert_to_value_tokens.js
+++ b/test/branded_token/convert_to_value_tokens.js
@@ -87,10 +87,9 @@ contract('BrandedToken::convertToValueTokens', async () => {
         0,
       );
 
-      // N.B.: values above are miniscule, because the
-      //       decimals for the test tokens are 18; consequently,
-      //       the potential for and degree of loss
-      //       as indicated above is considered acceptable
+      // N.B.: the potential for and degree of loss
+      //       as indicated above is considered acceptable,
+      //       depending on the number of decimal places (e.g., 18)
     });
   });
 });

--- a/test/branded_token/request_stake.js
+++ b/test/branded_token/request_stake.js
@@ -22,6 +22,7 @@ const { Event } = require('../test_lib/event_decoder.js');
 const web3 = require('../test_lib/web3.js');
 const utils = require('../test_lib/utils');
 const brandedTokenUtils = require('./utils');
+const config = require('../test_lib/config');
 
 const BrandedToken = artifacts.require('BrandedToken');
 const EIP20TokenMockFail = artifacts.require('EIP20TokenMockFail');
@@ -87,7 +88,7 @@ contract('BrandedToken::requestStake', async () => {
         valueToken.address,
         'BT',
         'BrandedToken',
-        18,
+        config.decimals,
         35,
         1,
         await accountProvider.get(),

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -15,6 +15,7 @@
 
 'use strict';
 
+const config = require('../test_lib/config');
 const web3 = require('../test_lib/web3.js');
 
 const BrandedToken = artifacts.require('BrandedToken');
@@ -36,7 +37,7 @@ module.exports.setupBrandedToken = async (
   );
   const symbol = 'BT';
   const name = 'BrandedToken';
-  const decimals = 18;
+  const { decimals } = config;
   const conversionRate = 35;
   const conversionRateDecimals = 1;
   const organization = await (

--- a/test/gateway_composer/utils.js
+++ b/test/gateway_composer/utils.js
@@ -17,6 +17,8 @@
 
 const BN = require('bn.js');
 
+const config = require('../test_lib/config');
+
 const BrandedToken = artifacts.require('BrandedToken');
 const MockBrandedTokenFail = artifacts.require('MockBrandedTokenFail');
 const GatewayComposer = artifacts.require('GatewayComposer');
@@ -27,7 +29,7 @@ const MockOrganization = artifacts.require('OrganizationMockPass');
 
 const symbol = 'Test';
 const name = 'Test';
-const decimals = 18;
+const { decimals } = config;
 const conversionRate = 1;
 const conversionRateDecimals = 0;
 

--- a/test/test_lib/config.js
+++ b/test/test_lib/config.js
@@ -1,0 +1,40 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { env } = require('process');
+
+/** Test wide configuration for various tests. */
+const config = {
+  /** Defaults to 18. Can be overriden with the environment variable OPENST_DECIMALS. */
+  get decimals() {
+    let decimals = 18;
+
+    if (env.OPENST_DECIMALS) {
+      decimals = Number.parseInt(env.OPENST_DECIMALS, 10);
+    }
+
+    return decimals;
+  },
+};
+
+module.exports = config;

--- a/test/utility_branded_token/constructor.js
+++ b/test/utility_branded_token/constructor.js
@@ -15,6 +15,7 @@
 
 'use strict';
 
+const config = require('../test_lib/config');
 const utils = require('../test_lib/utils');
 
 const UtilityBrandedToken = artifacts.require('UtilityBrandedToken');
@@ -27,7 +28,7 @@ contract('UtilityBrandedToken::constructor', async (accounts) => {
 
   const SYMBOL = 'MOCK';
   const NAME = 'Mock Token';
-  const DECIMALS = '5';
+  const { decimals: DECIMALS } = config;
 
   beforeEach(async () => {
     accountProvider = new utils.AccountProvider(accounts);

--- a/test/utility_branded_token/utils.js
+++ b/test/utility_branded_token/utils.js
@@ -15,6 +15,8 @@
 
 'use strict';
 
+const config = require('../test_lib/config');
+
 const TestUtilityBrandedToken = artifacts.require('TestUtilityBrandedToken');
 const EIP20TokenMock = artifacts.require('EIP20TokenMock');
 const MockOrganization = artifacts.require('MockOrganization');
@@ -25,7 +27,7 @@ const MockOrganization = artifacts.require('MockOrganization');
 module.exports.setupUtilityBrandedToken = async (accountProvider, internalActor) => {
   const SYMBOL = 'MOCK';
   const NAME = 'Mock Token';
-  const DECIMALS = '5';
+  const { decimals: DECIMALS } = config;
 
   const {
     mockOrganization,

--- a/tools/test_range.sh
+++ b/tools/test_range.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Copyright 2019 OpenST Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ----------------------------------------------------------------------------
+#
+# http://www.simpletoken.org/
+#
+# ----------------------------------------------------------------------------
+
+###
+# Runs tests sequentially for a range of decimal values.
+#
+# Example run with decimals 12 - 18 (inclusive):
+#
+# ```bash
+# npm run test:range -- 12 18
+# ```
+#
+# You can provide only one argument and the tests will run for that specific
+# decimal.
+###
+
+# Tracking the exit code to run further tests if they fail for a spcefic decimal.
+EXIT_CODE=0
+
+# Tracking failed decimals for error output.
+FAILED_DECIMALS=""
+
+function handle_error {
+    # On first iteration, no extra comma
+    if [ $EXIT_CODE -eq 0 ];
+    then
+        FAILED_DECIMALS="$1"
+    else
+        FAILED_DECIMALS="${FAILED_DECIMALS}, $1"
+    fi
+    EXIT_CODE=1
+}
+
+function handle_exit {
+    if [ $EXIT_CODE -ne 0 ];
+    then
+        echo ""
+        echo "### Errors for the following decimals:"
+        echo "${FAILED_DECIMALS}"
+        echo ""
+    else
+        echo ""
+        echo "### Done"
+        echo ""
+    fi
+
+    exit $EXIT_CODE
+}
+
+echo ""
+
+if [ $# -ne 1 ] && [ $# -ne 2 ];
+then
+    echo "Wrong number of parameters given."
+    echo "Run with two arguments: start and end of range inclusive."
+    echo "Example:"
+    echo "npm run test:range -- 16 20"
+    echo ""
+    echo "If you provide only one argument, the tests will be run for that value."
+    echo ""
+    exit 1
+fi
+
+# Start and end values should be provided on the command line.
+START=$1
+
+if [ $# -eq 1 ];
+then
+    END=$START
+else
+    END=$2
+fi
+
+for DECIMALS in $(seq "${START}" "${END}");
+do
+    echo "### Running tests with ${DECIMALS} decimals."
+    export OPENST_DECIMALS=$DECIMALS
+    npm test || handle_error $DECIMALS
+done
+
+handle_exit


### PR DESCRIPTION
This PR replicates the work done in https://github.com/OpenST/mosaic-contracts/pull/755 to add test coverage for arbitrary token decimals.

Resolves #172.