### PR TITLE
`npm run compile` should use node modules truffle version for contracts compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "scripts": {
     "build-package": "node tools/build_package.js",
-    "compile-all": "truffle compile --all",
-    "test": "truffle test",
+    "compile-all": "./node_modules/.bin/truffle compile --all",
+    "test": "./node_modules/.bin/truffle test",
     "prepack": "npm run compile-all && npm run build-package",
     "lint": "eslint migrations/*.js test/*/*.js tools/*.js -c .eslintrc"
   },


### PR DESCRIPTION
**Problem**
For compilation of contracts, publisher global truffle version is used. This is a problem since truffle global version can be different than node modules truffle version everytime mosaic contracts npm is published.
```
"compile": "truffle compile",
```

**Solution**
Use node modules truffle version for contracts compilation
```
"compile": "./node_modules/.bin/truffle compile",
```

Fixes #180 